### PR TITLE
AWS SSM Buildkite plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,4 +13,3 @@ steps:
     plugins:
       shellcheck#v1.3.0:
         files: hooks/**
-    skip: "Shellcheck doesn't pass right now"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,16 @@
+steps:
+  - label: ":shell: Tests"
+    plugins:
+      docker-compose#v4.8.0:
+        run: tests
+
+  - label: ":sparkles: Lint"
+    plugins:
+      plugin-linter#v3.0.0:
+        id: ecr
+
+  - label: ":shell: Shellcheck"
+    plugins:
+      shellcheck#v1.3.0:
+        files: hooks/**
+    skip: "Shellcheck doesn't pass right now"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":shell: Tests"
     plugins:
-      docker-compose#v4.8.0:
+      docker-compose#v4.9.0:
         run: tests
 
   - label: ":sparkles: Lint"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ steps:
   - label: ":sparkles: Lint"
     plugins:
       plugin-linter#v3.0.0:
-        id: ecr
+        id: aws-ssm
 
   - label: ":shell: Shellcheck"
     plugins:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Based on previous work by [zacharymctague](https://github.com/zacharymctague/aws-ssm-buildkite-plugin), [Linktree](https://github.com/blstrco/aws-sm-buildkite-plugin), and [Seek](https://github.com/seek-oss/aws-sm-buildkite-plugin).
 
-The plugin requires the `ssm:GetParameters` IAM permission for the parameters you specify.
+The plugin requires the `ssm:GetParameters` IAM permission for the parameters you specify. If the values are SecureStrings, it will also require `kms:Decrypt` on the corresponding KMS key.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# aws-ssm-buildkite-plugin
-🔑 Inject AWS SSM Parameters
+# AWS SSM Buildkite Plugin
+
+🔑 Injects AWS SSM Parameter Store parameters as environment variables into your build step.
+
+Based on previous work by [zacharymctague](https://github.com/zacharymctague/aws-ssm-buildkite-plugin), [Linktree](https://github.com/blstrco/aws-sm-buildkite-plugin), and [Seek](https://github.com/seek-oss/aws-sm-buildkite-plugin).
+
+The plugin requires the `ssm:GetParameters` IAM permission for the parameters you specify.
+
+## Example
+
+Add the following to your `pipeline.yml`:
+
+```yml
+steps:
+  - command: echo "Param One equals \$PARAMETER_ONE"
+    plugins:
+      - aws-ssm#v1.0.0:
+          parameters:
+            PARAMETER_ONE: /my/parameter
+            PARAMETER_TWO: /my/other/parameter
+```
+
+## Configuration
+
+### `parameters` (Required, object)
+
+- Specify a dictionary of `key: value` pairs to inject as environment variables, where the key is the name of the
+  environment variable to be set, and the value is the AWS SSM parameter path.
+
+## Developing
+
+To run the tests:
+
+```shell
+docker-compose run --rm tests
+```
+
+## Contributing
+
+1. Fork the repo
+2. Make the changes
+3. Run the tests
+4. Commit and push your changes
+5. Send a pull request

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.8"
 services:
   tests:
-    image: buildkite/plugin-tester
+    image: buildkite/plugin-tester:v3.0.1
     volumes:
       - ".:/plugin:ro"
   lint:
-    image: buildkite/plugin-linter
+    image: buildkite/plugin-linter:latest
     command: ["--id", "aws-ssm"]
     volumes:
       - ".:/plugin:ro"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+services:
+  tests:
+    image: buildkite/plugin-tester
+    volumes:
+      - ".:/plugin:ro"
+  lint:
+    image: buildkite/plugin-linter
+    command: ["--id", "aws-ssm"]
+    volumes:
+      - ".:/plugin:ro"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -17,10 +17,16 @@ done
 
 # Fetch the parameters from SSM in groups of 10
 for ((i = 0; i < ${#names[@]}; i += limit)); do
-  page=("${names[@]:i:limit}")
+  aws_command=(
+    aws ssm get-parameters
+    --with-decryption
+    --query "Parameters[].[Name,Value]"
+    --output text
+    --names
+  )
+  aws_command+=("${names[@]:i:limit}")
 
   # Split the results as tab-delimited values
-  # shellcheck disable=SC2048,SC2086
   while IFS=$'\t' read -r name value
   do
     # Loop through the list of SSM parameter names until we find a match to correlate with the environment variable.
@@ -33,9 +39,5 @@ for ((i = 0; i < ${#names[@]}; i += limit)); do
         echo "Exported ${key} as value of parameter ${name}"
       fi
     done
-  done < <(aws ssm get-parameters \
-    --with-decryption \
-    --query "Parameters[].[Name,Value]" \
-    --output text \
-    --names ${page[*]})
+  done < <("${aws_command[@]}")
 done

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-limit=10
+limit=10 # The maximum allowed for GetParameters
 keys=()
 names=()
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+limit=10
+keys=()
+names=()
+
+# Extract the environment variable keys and SSM parameter names.
+for param in ${!BUILDKITE_PLUGIN_AWS_SSM_PARAMETERS_*}; do
+  key="${param/BUILDKITE_PLUGIN_AWS_SSM_PARAMETERS_/}"
+  name="${!param}"
+
+  keys+=("${key}")
+  names+=("${name}")
+done
+
+# Fetch the parameters from SSM in groups of 10
+for ((i = 0; i < ${#names[@]}; i += limit)); do
+  page=("${names[@]:i:limit}")
+
+  # Split the results as tab-delimited values
+  # shellcheck disable=SC2048,SC2086
+  while IFS=$'\t' read -r name value
+  do
+    # Loop through the list of SSM parameter names until we find a match to correlate with the environment variable.
+    # While this is O(n*n), it should still be faster than making an API call for each parameter.
+    # We can't guarantee we're using Bash 4 so we can't use dictionaries.
+    for j in "${!names[@]}"; do
+      if [ "${names[$j]}" = "${name}" ]; then
+        key="${keys[$j]}"
+        export "${key}=${value}"
+        echo "Exported ${key} as value of parameter ${name}"
+      fi
+    done
+  done < <(aws ssm get-parameters \
+    --with-decryption \
+    --query "Parameters[].[Name,Value]" \
+    --output text \
+    --names ${page[*]})
+done

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -15,8 +15,11 @@ for param in ${!BUILDKITE_PLUGIN_AWS_SSM_PARAMETERS_*}; do
   names+=("${name}")
 done
 
-# Fetch the parameters from SSM in groups of 10
+# Fetch the parameters from SSM in batches of $limit.
 for ((i = 0; i < ${#names[@]}; i += limit)); do
+  keys_page=("${keys[@]:i:limit}")
+  names_page=("${names[@]:i:limit}")
+
   aws_command=(
     aws ssm get-parameters
     --with-decryption
@@ -24,17 +27,16 @@ for ((i = 0; i < ${#names[@]}; i += limit)); do
     --output text
     --names
   )
-  aws_command+=("${names[@]:i:limit}")
+  aws_command+=("${names_page[@]}")
 
-  # Split the results as tab-delimited values
-  while IFS=$'\t' read -r name value
-  do
+  # Split the results as tab-delimited values.
+  while IFS=$'\t' read -r name value; do
     # Loop through the list of SSM parameter names until we find a match to correlate with the environment variable.
-    # While this is O(n*n), it should still be faster than making an API call for each parameter.
+    # While this is O(limit^2), it should still be faster than making an API call for each parameter.
     # We can't guarantee we're using Bash 4 so we can't use dictionaries.
-    for j in "${!names[@]}"; do
-      if [ "${names[$j]}" = "${name}" ]; then
-        key="${keys[$j]}"
+    for j in "${!names_page[@]}"; do
+      if [[ "${names_page[$j]}" = "${name}" ]]; then
+        key="${keys_page[$j]}"
         export "${key}=${value}"
         echo "Exported ${key} as value of parameter ${name}"
       fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,14 @@
+name: aws-ssm
+description: Injects AWS SSM Parameter Store parameters as environment variables into your build step
+author: https://github.com/buildkite-plugins
+public: true
+requirements:
+  - aws
+  - bash
+configuration:
+  properties:
+    parameters:
+      type: object
+  required:
+    - parameters
+  additionalProperties: false

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment to enable stub debugging
+# export AWS_STUB_DEBUG=/dev/tty
+
+@test "Exports parameters from SSM Store" {
+    export BUILDKITE_PLUGIN_AWS_SSM_PARAMETERS_PARAMETER_ONE=/my/parameter/one
+    export BUILDKITE_PLUGIN_AWS_SSM_PARAMETERS_PARAMETER_TWO=/my/parameter/two
+
+    # Deliberately output the parameters in a different order to ensure they are mapped correctly
+    stub aws "ssm get-parameters --with-decryption --query Parameters[].[Name,Value] --output text --names /my/parameter/one /my/parameter/two : echo -e \"/my/parameter/two\tsecrettwo\n/my/parameter/one\tsecretone\""
+
+    run "$PWD/hooks/pre-command"
+
+    assert_output --partial <<EOM
+Exported PARAMETER_TWO as value of parameter /my/parameter/two
+Exported PARAMETER_ONE as value of parameter /my/parameter/one
+EOM
+
+    assert_success
+
+    unstub aws
+}

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -14,10 +14,8 @@ load '/usr/local/lib/bats/load.bash'
 
     run "$PWD/hooks/pre-command"
 
-    assert_output --partial <<EOM
-Exported PARAMETER_TWO as value of parameter /my/parameter/two
-Exported PARAMETER_ONE as value of parameter /my/parameter/one
-EOM
+    assert_output --partial "Exported PARAMETER_TWO as value of parameter /my/parameter/two"
+    assert_output --partial "Exported PARAMETER_ONE as value of parameter /my/parameter/one"
 
     assert_success
 


### PR DESCRIPTION
Injects AWS SSM Parameter Store parameters as environment variables into your build step.

Based on previous work by [zacharymctague](https://github.com/zacharymctague/aws-ssm-buildkite-plugin), [Linktree](https://github.com/blstrco/aws-sm-buildkite-plugin), and [Seek](https://github.com/seek-oss/aws-sm-buildkite-plugin).

Reimplemented to fetch parameters in pages of 10 instead of singly, which should be faster when there are many parameters.

(CI won't pass while the repo is private)