### PR TITLE
Remove explicit targeting of the hosted queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,20 +1,14 @@
 steps:
   - label: ":shell: Tests"
-    agents:
-      queue: "hosted"
     plugins:
       - plugin-tester#v1.1.1: ~
 
   - label: ":sparkles: Lint"
-    agents:
-      queue: "hosted"
     plugins:
       - plugin-linter#v3.3.0:
           id: aws-ssm
 
   - label: ":shell: Shellcheck"
-    agents:
-      queue: "hosted"
     plugins:
       - shellcheck#v1.3.0:
           files: hooks/**


### PR DESCRIPTION
Same premise as [this](https://github.com/buildkite-plugins/vault-secrets-buildkite-plugin/pull/57) - queue is now defaulted - I don't claim work done, the stewardship of @yob!